### PR TITLE
Fix #17: per-sample description missing on first nav + scrollbar/schema fixes

### DIFF
--- a/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/LayoutService.cs
+++ b/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/LayoutService.cs
@@ -1,21 +1,22 @@
 namespace dymaptic.GeoBlazor.Core.Sample.Shared.Shared;
 
-// LayoutStateService.cs
 public class LayoutService
 {
     public SamplePage? CurrentPage { get; private set; }
+
+    // URI the CurrentPage was registered for. Consumers should only treat
+    // CurrentPage as live when this matches the layout's current URI —
+    // that way stale references from a previously-rendered SamplePage are
+    // silently ignored after navigation, with no race against component
+    // initialization order.
+    public string? PageUri { get; private set; }
+
     public event Action? OnPageChanged;
 
-    public void SetCurrentPage(SamplePage page)
+    public void SetCurrentPage(SamplePage page, string uri)
     {
         CurrentPage = page;
-        OnPageChanged?.Invoke();
-    }
-
-    public void ClearCurrentPage()
-    {
-        if (CurrentPage is null) return;
-        CurrentPage = null;
+        PageUri = uri;
         OnPageChanged?.Invoke();
     }
 }

--- a/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/MainLayout.razor
+++ b/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/MainLayout.razor
@@ -23,13 +23,13 @@
     <DynamicComponent Type="NavMenuType" />
     <main>
         <div class="main-links">
-            
+
             <SourceNav />
-            @if (LayoutService.CurrentPage is not null)
+            @if (EffectiveCurrentPage is { } page)
             {
-                for (int i = 0; i < LayoutService.CurrentPage.PageLinks.Count; i++)
+                for (int i = 0; i < page.PageLinks.Count; i++)
                 {
-                    NavMenu.PageLink pageLink = LayoutService.CurrentPage.PageLinks[i];
+                    NavMenu.PageLink pageLink = page.PageLinks[i];
                     string btnType = _btnTypes[i % _btnTypes.Length];
                     <a class="btn @btnType" target="_blank" rel="noopener" href="@pageLink.Href">@pageLink.Title</a>
                 }
@@ -38,7 +38,7 @@
 
         <article class="content">
             @Body
-            @if (LayoutService.CurrentPage is { Description: { Length: > 0 } description })
+            @if (EffectiveCurrentPage is { Description: { Length: > 0 } description })
             {
                 <details class="sample-description">
                     <summary>About this sample</summary>
@@ -78,7 +78,7 @@
     public required RouteData RouteData { get; set; }
 
     protected override void OnInitialized()
-        {
+    {
         base.OnInitialized();
 
         LayoutService.OnPageChanged += StateHasChanged;
@@ -87,11 +87,13 @@
 
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
-        // Clear before the new page renders. If the new page inherits SamplePage,
-        // its OnInitialized will set CurrentPage again. Pages that don't inherit
-        // SamplePage (Home, NotFound, etc.) leave it null so the layout doesn't
-        // render stale per-page metadata.
-        LayoutService.ClearCurrentPage();
+        // URI-dependent metadata (title, og:url, JSON-LD @id) needs to update on
+        // every navigation, even before the next page's OnInitialized runs. We
+        // deliberately don't clear LayoutService.CurrentPage here — the
+        // EffectiveCurrentPage getter discards stale references whose URI no
+        // longer matches, which avoids a render-order race between the layout
+        // and the new SamplePage's initialization.
+        StateHasChanged();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -127,6 +129,19 @@
 
     private string CurrentSlug => NavigationManager.ToBaseRelativePath(CanonicalPageUrl);
 
+    // Only treat LayoutService.CurrentPage as live when its registered URI
+    // matches the URI the layout is currently rendering for. This guards
+    // against two cases:
+    //  - Stale CurrentPage from a previous SamplePage after navigating to a
+    //    non-SamplePage route (Home, NotFound, etc).
+    //  - Render-order races where the new SamplePage hasn't yet run its
+    //    OnInitialized but the layout has already started a render pass.
+    private SamplePage? EffectiveCurrentPage =>
+        LayoutService.CurrentPage is { } page &&
+        string.Equals(LayoutService.PageUri, NavigationManager.Uri, StringComparison.Ordinal)
+            ? page
+            : null;
+
     private string MetaTitle
     {
         get
@@ -134,7 +149,7 @@
             string slug = CurrentSlug;
             if (string.IsNullOrEmpty(slug)) return "GeoBlazor Samples";
             string title = SlugToTitle(slug);
-            return LayoutService.CurrentPage is not null
+            return EffectiveCurrentPage is not null
                 ? $"{title} — GeoBlazor Sample"
                 : title;
         }
@@ -144,7 +159,7 @@
     {
         get
         {
-            string? d = LayoutService.CurrentPage?.Description;
+            string? d = EffectiveCurrentPage?.Description;
             if (string.IsNullOrWhiteSpace(d))
             {
                 return DefaultMetaDescription;
@@ -166,7 +181,34 @@
             string pageUrl = CanonicalPageUrl;
             string siteUrl = NavigationManager.BaseUri.TrimEnd('/');
             string slug = CurrentSlug;
-            string pageName = string.IsNullOrEmpty(slug) ? "GeoBlazor Samples" : SlugToTitle(slug);
+            bool isHome = string.IsNullOrEmpty(slug);
+            string pageName = isHome ? "GeoBlazor Samples" : SlugToTitle(slug);
+            SamplePage? currentPage = EffectiveCurrentPage;
+
+            Dictionary<string, object?> webPage = new()
+            {
+                ["@type"] = "WebPage",
+                ["@id"] = $"{pageUrl}#webpage",
+                ["url"] = pageUrl,
+                ["name"] = pageName,
+                ["isPartOf"] = new Dictionary<string, object?> { ["@id"] = $"{siteUrl}/#website" },
+                ["about"] = new Dictionary<string, object?> { ["@id"] = "https://geoblazor.com/#software" }
+            };
+
+            string? pageDescription = currentPage?.Description;
+            if (!string.IsNullOrWhiteSpace(pageDescription))
+            {
+                webPage["description"] = pageDescription;
+            }
+
+            // Per-page keywords: the page title's words combined with the site
+            // baseline. Gives each WebPage entry distinguishable content beyond
+            // url/name so crawlers see meaningful variation per sample.
+            if (currentPage is not null && !isHome)
+            {
+                webPage["keywords"] = BuildKeywords(pageName);
+                webPage["mainEntity"] = new Dictionary<string, object?> { ["@id"] = $"{pageUrl}#code" };
+            }
 
             List<object> graph =
             [
@@ -207,24 +249,10 @@
                     ["codeRepository"] = "https://github.com/dymaptic/GeoBlazor",
                     ["publisher"] = new Dictionary<string, object?> { ["@id"] = "https://geoblazor.com/#organization" }
                 },
-                new Dictionary<string, object?>
-                {
-                    ["@type"] = "WebPage",
-                    ["@id"] = $"{pageUrl}#webpage",
-                    ["url"] = pageUrl,
-                    ["name"] = pageName,
-                    ["isPartOf"] = new Dictionary<string, object?> { ["@id"] = $"{siteUrl}/#website" },
-                    ["about"] = new Dictionary<string, object?> { ["@id"] = "https://geoblazor.com/#software" }
-                }
+                webPage
             ];
 
-            string? pageDescription = LayoutService.CurrentPage?.Description;
-            if (!string.IsNullOrWhiteSpace(pageDescription))
-            {
-                ((Dictionary<string, object?>)graph[^1])["description"] = pageDescription;
-            }
-
-            if (LayoutService.CurrentPage is not null)
+            if (currentPage is not null)
             {
                 Dictionary<string, object?> sourceCode = new()
                 {
@@ -235,7 +263,9 @@
                     ["programmingLanguage"] = new[] { "C#", "Blazor" },
                     ["codeRepository"] = "https://github.com/dymaptic/GeoBlazor-Samples",
                     ["isPartOf"] = new Dictionary<string, object?> { ["@id"] = $"{pageUrl}#webpage" },
-                    ["about"] = new Dictionary<string, object?> { ["@id"] = "https://geoblazor.com/#software" }
+                    ["mainEntityOfPage"] = new Dictionary<string, object?> { ["@id"] = $"{pageUrl}#webpage" },
+                    ["about"] = new Dictionary<string, object?> { ["@id"] = "https://geoblazor.com/#software" },
+                    ["keywords"] = BuildKeywords(pageName)
                 };
 
                 if (!string.IsNullOrWhiteSpace(pageDescription))
@@ -254,6 +284,13 @@
 
             return System.Text.Json.JsonSerializer.Serialize(root, JsonOptions);
         }
+    }
+
+    private static string[] BuildKeywords(string pageName)
+    {
+        string[] nameParts = pageName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        string[] baseline = ["GeoBlazor", "Blazor", "ArcGIS", ".NET", "mapping"];
+        return [.. nameParts, .. baseline];
     }
 
     private static string SlugToTitle(string slug)

--- a/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/MainLayout.razor.css
+++ b/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/MainLayout.razor.css
@@ -58,8 +58,10 @@ article.content {
     flex-grow: 1;
     margin: 0 auto;
     padding-bottom: 16rem;
-    height: calc(100vh - 10rem);
-    overflow-y: auto;
+    /* On narrow screens <main> handles scrolling; setting a fixed
+       height + overflow here too produced nested scrollbars. The wider
+       media queries below switch <main> to overflow:hidden and re-enable
+       inner scrolling on article. */
 }
 
 @media (min-width: 1075px) {
@@ -81,6 +83,8 @@ article.content {
         padding-right: 1.5rem;
         padding-bottom: 14rem;
         width: calc(100vw - 23rem);
+        height: calc(100vh - 10rem);
+        overflow-y: auto;
     }
 }
 

--- a/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/SamplePage.cs
+++ b/samples/core/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/SamplePage.cs
@@ -7,6 +7,9 @@ public abstract class SamplePage: ComponentBase
     [Inject]
     public required LayoutService LayoutService { get; set; }
 
+    [Inject]
+    public required NavigationManager NavigationManager { get; set; }
+
     public abstract List<NavMenu.PageLink> PageLinks { get; }
 
     /// <summary>
@@ -21,6 +24,6 @@ public abstract class SamplePage: ComponentBase
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        LayoutService.SetCurrentPage(this);
+        LayoutService.SetCurrentPage(this, NavigationManager.Uri);
     }
 }


### PR DESCRIPTION
Follow-up fixes for #17 addressing Tim's testing feedback and the two unresolved Copilot review comments.

## Tim's feedback

> "About this page" never shows on first navigation from the navbar, only after a page refresh.
> The Schema.org LD-JSON is too static for the site, each page should have somewhat different content, especially the description and url.

**Root cause for both:** the `MainLayout.OnLocationChanged` handler cleared `LayoutService.CurrentPage` on every navigation, expecting the next `SamplePage.OnInitialized` to re-register. But on first nav from the navbar, the layout's render after the clear could land before the new SamplePage had run its `OnInitialized`, so the description / SoftwareSourceCode / per-page meta tags rendered against `CurrentPage == null`. That's also why the JSON-LD looked "static" — the per-page description / SoftwareSourceCode entry was missing on first paint.

**Fix:** key `LayoutService.CurrentPage` to the URI it was registered for. `SamplePage.OnInitialized` now passes `NavigationManager.Uri` when calling `SetCurrentPage`. MainLayout reads through a new `EffectiveCurrentPage` getter that only returns the registered page when its URI matches `NavigationManager.Uri`. No timing dependency, and stale references after navigating to a non-SamplePage route (Home/NotFound) are silently ignored — same guarantee the explicit `ClearCurrentPage` was trying to provide, without the race.

While there, enrich the per-page JSON-LD with `keywords` derived from the page name plus `mainEntity` / `mainEntityOfPage` cross-references between WebPage and SoftwareSourceCode, so each sample page emits visibly distinct schema content beyond just url/name.

## Unresolved Copilot comments addressed

- **Nested scrolling on narrow layouts** (`MainLayout.razor.css:63`): `article.content` had a fixed `height: calc(100vh - 10rem)` + `overflow-y: auto` at all widths, and on `<1075px` so did the parent `<main>` — double scrollbars. Moved both into the `>=1075px` media query, where `<main>` switches to `overflow:hidden` and inner article scrolling is what we want.
- **Stale `CurrentPage` after navigating to a non-SamplePage route**: subsumed by the URI-key approach above (the thread was marked resolved by the original `ClearCurrentPage` change, but the new approach handles both this case and Tim's first-nav case with a single mechanism).

Other Copilot comments were already addressed in the existing PR commits (`Dispose()` no longer disposes the injected `HttpClient`; `summary::marker` cleared for cross-browser parity; `MetaTitle` only appends "— GeoBlazor Sample" when on a sample page; `SlugToTitle` takes the last `/`-segment; `CanonicalPageUrl` strips query/fragment).

## Files changed

- `LayoutService.cs` — add `PageUri`; `SetCurrentPage(page, uri)`; drop `ClearCurrentPage` (no longer needed)
- `SamplePage.cs` — inject `NavigationManager`; pass `Uri` when registering
- `MainLayout.razor` — `EffectiveCurrentPage` getter; use it in render, meta tags, and JSON-LD; `OnLocationChanged` now just calls `StateHasChanged`; enrich JSON-LD per-page
- `MainLayout.razor.css` — move article fixed-height + overflow into `>=1075px` media query

## Test plan

- [ ] On first-time navigation from navbar (cold load to Home, then click a sample link), "About this sample" details block renders without refresh.
- [ ] Per-page `<meta name="description">`, `og:url`, and JSON-LD `WebPage`/`SoftwareSourceCode` reflect the new sample on each navigation.
- [ ] Navigate from a sample to Home — description disappears, no stale per-page meta.
- [ ] On `<1075px` viewport, no nested/double scrollbars on sample pages with long content.
- [ ] On `>=1075px`, article still scrolls independently inside main as before.

Targets `feature/schema-org-jsonld` so it stacks into #17.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YTfaPEqs4thB29DjZ3RKGA)_