### PR TITLE
Filter Iowa bridges by deck condition only, matching the renderer

### DIFF
--- a/projects/IowaBridges/IowaBridges/Components/Bridges/BridgeFilterState.cs
+++ b/projects/IowaBridges/IowaBridges/Components/Bridges/BridgeFilterState.cs
@@ -60,13 +60,10 @@ public sealed class BridgeFilterState
             return null;
         }
 
-        // Build allowed code list from condition fields. Composite condition = min of the three,
-        // where 'N' means "not applicable" (commonly culverts) — we treat as 99/unknown and skip.
-        // The Arcade renderer maps:
-        //   0-4 -> Poor, 5-6 -> Fair, 7-9 -> Good
-        // For server-side filtering, mirror that by requiring at least one of the three condition
-        // fields to fall in the matching code set. (Approximate but readable; exact min requires
-        // server Arcade which the NBI service does not support.)
+        // Filter on the SAME field the renderer symbolizes by (DECK_COND_058) so the
+        // visible dot colors always match the checked condition boxes. The renderer maps:
+        //   0-4 -> Poor (red), 5-6 -> Fair (yellow), 7-9 -> Good (green)
+        // Filtering on deck condition alone keeps symbology and filtering consistent.
 
         var allowed = new List<string>();
         if (ShowPoor) allowed.AddRange(new[] { "0", "1", "2", "3", "4" });
@@ -74,9 +71,6 @@ public sealed class BridgeFilterState
         if (ShowGood) allowed.AddRange(new[] { "7", "8", "9" });
 
         var quoted = string.Join(",", allowed.Select(c => $"'{c}'"));
-        return
-            $"DECK_COND_058 IN ({quoted}) OR " +
-            $"SUPERSTRUCTURE_COND_059 IN ({quoted}) OR " +
-            $"SUBSTRUCTURE_COND_060 IN ({quoted})";
+        return $"DECK_COND_058 IN ({quoted})";
     }
 }


### PR DESCRIPTION
## What

The Iowa Bridges sample's sidebar condition filter built a definition expression matching a bridge if **any** of `DECK_COND_058`, `SUPERSTRUCTURE_COND_059`, or `SUBSTRUCTURE_COND_060` fell in the selected NBI code range. The map's `UniqueValueRenderer`, however, colors each dot **solely by `DECK_COND_058`**.

That mismatch meant a bridge could keep a "Good"-colored dot (deck = 8) while still qualifying through a poor superstructure or substructure rating, so dots would persist on the map after the user unchecked the box for their visible color.

This changes `BridgeFilterState.BuildConditionClause()` to filter on the same field the renderer symbolizes by:

```sql
-- before
DECK_COND_058 IN (...) OR SUPERSTRUCTURE_COND_059 IN (...) OR SUBSTRUCTURE_COND_060 IN (...)
-- after
DECK_COND_058 IN (...)
```

Now the dots that disappear always match the unchecked boxes. Also removes a stale comment that referenced an "Arcade renderer" — the renderer classifies by `DECK_COND_058` directly (see the `DEVIATION FROM PROMPT` note in `BridgeRendererFactory`).

## Why

Keeps the live demo, the [accompanying blog post](https://geoblazor.com/blog/building-with-claude-code-and-geoblazor), and this sample consistent on how condition filtering works.

## Testing

- `dotnet build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)